### PR TITLE
Run restorecon on msttcorefonts to fix selinux err

### DIFF
--- a/plugins/util/core_fonts.sh
+++ b/plugins/util/core_fonts.sh
@@ -16,6 +16,7 @@ else
         cabextract -L -d "$workingdir/msttcorefonts" "$file"
     done
     mv "$workingdir/msttcorefonts" "/usr/share/fonts/"
+    restorecon -r -v "/usr/share/fonts/msttcorefonts/"
     show_msg "Rebuilding font cache"
     fc-cache -f
 fi


### PR DESCRIPTION
After msttcorefonts are moved to ./usr/share/fonts they had wrong selinux context, preventing the fonts from bein accessible, and leading to blank text in apps that tried to use them. Must run restorecon against directory to get correct font context.

Ref issue #121 