### PR TITLE
Adding metadata and logic to display software licenses

### DIFF
--- a/app.js
+++ b/app.js
@@ -472,6 +472,8 @@ const Application = new Lang.Class({
             for (let item in this._plugins[category]) {
                 let plugin = this._plugins[category][item];
 
+                let has_license = plugin.libre || plugin.proprietary
+
                 let grid = new Gtk.Grid({
                     row_spacing: 5,
                     column_spacing: 10,
@@ -516,7 +518,13 @@ const Application = new Lang.Class({
                     image.set_from_icon_name("system-run", Gtk.IconSize.DIALOG);
                 }
 
-                grid.attach(image, 0, 1, 1, 2);
+                let nb_rows
+                if (has_license) {
+                  nb_rows = 3
+                } else {
+                  nb_rows = 2
+                }
+                grid.attach(image, 0, 1, 1, nb_rows);
 
                 let label = new Gtk.Label({
                     halign: Gtk.Align.START,
@@ -539,6 +547,36 @@ const Application = new Lang.Class({
                 description.connect("query_tooltip", settooltip(plugin));
 
                 grid.attach(description, 1, 2, 1, 1);
+
+
+                if (has_license) {
+                  let license = new Gtk.Label({
+                      halign: Gtk.Align.START,
+                      expand: true
+                  });
+
+                  let license_type;
+                  if (plugin.libre && !plugin.proprietary && !plugin.patented) {
+                    license_type = "Libre"
+                  } else if (!plugin.libre && plugin.proprietary && !plugin.patented) {
+                    license_type = "Proprietary"
+                  } else if (!plugin.libre && !plugin.proprietary && plugin.patented) {
+                    license_type = "Patented"
+                  } else {
+                    license_type = "Mixed"
+                  }
+
+                  let license_description;
+                  if (plugin.license) {
+                    license_description = " (" + plugin.license + ")"
+                  } else {
+                    license_description = ""
+                  }
+
+                  license.set_markup("<i>" + license_type + license_description + "</i>");
+                  license.set_ellipsize(Pango.EllipsizeMode.END);
+                  grid.attach(license, 1, 3, 1, 1);
+              }
 
                 if (plugin.scripts) {
                     if (plugin.scripts.exec) {

--- a/plugins/androidstudio.plugin/metadata.json
+++ b/plugins/androidstudio.plugin/metadata.json
@@ -2,6 +2,8 @@
 	"icon": "android-studio",
 	"label": "Android Studio",
 	"description": "Official IDE for Android application development, based on IntelliJ IDEA.",
+	"license": "Apache 2.0",
+	"libre": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/archive.plugin/metadata.json
+++ b/plugins/archive.plugin/metadata.json
@@ -2,6 +2,9 @@
 	"icon": "file-roller",
 	"label": "Archive formats",
 	"description": "Utilized by file-roller to extract or compress different formats.",
+	"license": "Freeware, GPLv2+, GPLv3+, LGPLv2(+)",
+	"libre": true,
+	"proprietary": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/atom.plugin/metadata.json
+++ b/plugins/atom.plugin/metadata.json
@@ -2,6 +2,8 @@
 	"icon": "atom",
 	"label": "Atom",
 	"description": "A hackable text editor for the 21st Century.",
+	"license": "MIT",
+	"libre": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/brackets.plugin/metadata.json
+++ b/plugins/brackets.plugin/metadata.json
@@ -2,6 +2,8 @@
 	"icon": "brackets",
 	"label": "Brackets",
 	"description": "An open source code editor for web designers and front-end developers.",
+	"license": "MIT",
+	"libre": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/chrome.plugin/metadata.json
+++ b/plugins/chrome.plugin/metadata.json
@@ -2,6 +2,8 @@
 	"icon": "google-chrome",
 	"label": "Google Chrome",
 	"description": "A fast, simple and secure web browser, built for the modern web.",
+	"license": "Freeware under Google Chrome Terms of Service",
+	"proprietary": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/clion.plugin/metadata.json
+++ b/plugins/clion.plugin/metadata.json
@@ -2,6 +2,8 @@
 	"icon": "clion",
 	"label": "CLion",
 	"description": "Fully integrated C/C++ Development Environment.",
+	"license": "Commercial with free 30 day trial",
+	"proprietary": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/codecs.plugin/metadata.json
+++ b/plugins/codecs.plugin/metadata.json
@@ -2,6 +2,9 @@
 	"icon": "applications-multimedia",
 	"label": "Multimedia codecs",
 	"description": "Utilized by multimedia applications to encode or decode audio or video streams.",
+	"license": "Distributable, BSD, GPLv2(+), LGPLv2(+), GFDL",
+	"libre": true,
+	"proprietary": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/dropbox.plugin/metadata.json
+++ b/plugins/dropbox.plugin/metadata.json
@@ -2,6 +2,8 @@
 	"icon": "dropbox",
 	"label": "Dropbox for Nautilus",
 	"description": "Dropbox integration for the GNOME file manager.",
+	"license": "GPL, custom CC-BY-ND-3",
+	"libre": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/engines.plugin/metadata.json
+++ b/plugins/engines.plugin/metadata.json
@@ -2,6 +2,8 @@
 	"icon": "preferences-desktop-theme",
 	"label": "Theme engines",
 	"description": "Used by GTK themes to draw widgets.",
+	"license": "LGPLv2 or LGPLv3",
+	"libre": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/firefox.plugin/metadata.json
+++ b/plugins/firefox.plugin/metadata.json
@@ -2,6 +2,8 @@
 	"icon": "firefox",
 	"label": "Mozilla Firefox",
 	"description": "An open-source web browser, designed for standards compliance, performance and portability.",
+	"license": "MPLv1.1 or GPLv2+ or LGPLv2+",
+	"libre": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/flash.plugin/metadata.json
+++ b/plugins/flash.plugin/metadata.json
@@ -2,6 +2,7 @@
 	"icon": "flash",
 	"label": "Adobe Flash",
 	"description": "Browser plug-in and rich Internet application runtime.",
+	"proprietary": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/fontconfig.plugin/metadata.json
+++ b/plugins/fontconfig.plugin/metadata.json
@@ -1,6 +1,9 @@
 {
 	"label": "Better font rendering",
 	"description": "Improve the font rendering for better readability.",
+	"license": "FTL or GPLv2+, BSD, MIT, Public Domain, zlib, Apache 2.0, patented",
+	"libre": true,
+	"patented": true,
 	"category": "Tweaks",
 	"scripts": {
 		"exec": {

--- a/plugins/gnomedev.plugin/metadata.json
+++ b/plugins/gnomedev.plugin/metadata.json
@@ -2,6 +2,7 @@
 	"icon": "applications-development",
 	"label": "GNOME developement tools",
 	"description": "Everything you need to start developing software for GNOME.",
+	"libre": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/hangouts.plugin/metadata.json
+++ b/plugins/hangouts.plugin/metadata.json
@@ -2,6 +2,8 @@
 	"icon": "web-google-hangouts",
 	"label": "Hangouts plugin",
 	"description": "Have voice and video conversations from your computer.",
+	"license": "Freeware",
+	"proprietary": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/intellijideacommunity.plugin/metadata.json
+++ b/plugins/intellijideacommunity.plugin/metadata.json
@@ -2,6 +2,8 @@
 	"icon": "intellij-idea-ce",
 	"label": "IntelliJ IDEA Community Edition",
 	"description": "A free and open-source IDE for Java, Groovy, Scala and Android development.",
+	"license": "Apache 2.0",
+	"libre": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/intellijideaultimate.plugin/metadata.json
+++ b/plugins/intellijideaultimate.plugin/metadata.json
@@ -2,6 +2,8 @@
 	"icon": "intellij-idea-ue",
 	"label": "IntelliJ IDEA Ultimate Edition",
 	"description": "A complete toolset for web, mobile and enterprise development.",
+	"license": "Commercial with free 30 day trial",
+	"proprietary": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/jdk.plugin/metadata.json
+++ b/plugins/jdk.plugin/metadata.json
@@ -2,6 +2,9 @@
 	"icon": "java",
 	"label": "Oracle JDK",
 	"description": "Development environment for building applications using the Java programming language.",
+	"license": "Sun License, GPL",
+	"libre": true,
+	"proprietary": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/jre.plugin/metadata.json
+++ b/plugins/jre.plugin/metadata.json
@@ -2,6 +2,9 @@
 	"icon": "java",
 	"label": "Oracle JRE",
 	"description": "Allows to run applications written in the Java programming language.",
+	"license": "Sun License, GPL",
+	"libre": true,
+	"proprietary": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/libdvdcss.plugin/metadata.json
+++ b/plugins/libdvdcss.plugin/metadata.json
@@ -1,6 +1,8 @@
 {
 	"label": "Encrypted DVD playback (libdvdcss)",
 	"description": "Simple library designed for accessing DVDs like a block device.",
+	"license": "GPLv2+",
+	"libre": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/lighttable.plugin/metadata.json
+++ b/plugins/lighttable.plugin/metadata.json
@@ -2,6 +2,8 @@
 	"icon": "lticon",
 	"label": "LightTable",
 	"description": "The next generation code editor.",
+	"license": "MIT",
+	"libre": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/masterpdfeditor.plugin/metadata.json
+++ b/plugins/masterpdfeditor.plugin/metadata.json
@@ -2,6 +2,8 @@
 	"icon": "master-pdf-editor",
 	"label": "Master PDF editor",
 	"description": "A convenient and smart XPS & PDF editor.",
+	"license": "Free for non-commercial use",
+	"proprietary": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/msttcorefonts.plugin/metadata.json
+++ b/plugins/msttcorefonts.plugin/metadata.json
@@ -2,6 +2,8 @@
 	"icon": "preferences-desktop-font",
 	"label": "Microsoft TrueType core fonts",
 	"description": "Times New Roman, Arial, Comic Sans and other core Microsoft fonts.",
+	"license": "Freeware",
+	"proprietary": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/numix.plugin/metadata.json
+++ b/plugins/numix.plugin/metadata.json
@@ -2,6 +2,8 @@
 	"icon": "numix",
 	"label": "Numix themes",
 	"description": "GTK and icon themes from the Numix Project.",
+	"license": "GPLv3",
+	"libre": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/phpstorm.plugin/metadata.json
+++ b/plugins/phpstorm.plugin/metadata.json
@@ -2,6 +2,8 @@
 	"icon": "phpstorm",
 	"label": "PhpStorm",
 	"description": "The Most Intelligent PHP IDE.",
+	"license": "Commercial with free 30 day trial",
+	"proprietary": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/popcorntime.plugin/metadata.json
+++ b/plugins/popcorntime.plugin/metadata.json
@@ -2,6 +2,8 @@
 	"icon": "popcorn-time",
 	"label": "Popcorn Time",
 	"description": "Watch the best movies instantly in HD, with subtitles, for free.",
+	"license": "GPLv3",
+	"libre": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/pycharmprofessional.plugin/metadata.json
+++ b/plugins/pycharmprofessional.plugin/metadata.json
@@ -2,6 +2,8 @@
 	"icon": "pycharm",
 	"label": "PyCharm Professional Edition",
 	"description": "Python IDE & Django IDE for Web Developers.",
+	"license": "Commercial with free 30 day trial",
+	"proprietary": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/rubymine.plugin/metadata.json
+++ b/plugins/rubymine.plugin/metadata.json
@@ -2,6 +2,8 @@
 	"icon": "rubymine",
 	"label": "RubyMine",
 	"description": "The Most Intelligent Ruby and Rails IDE.",
+	"license": "Commercial with free 30 day trial",
+	"proprietary": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/skype.plugin/metadata.json
+++ b/plugins/skype.plugin/metadata.json
@@ -2,6 +2,8 @@
 	"icon": "skype",
 	"label": "Skype",
 	"description": "Stay in touch with your family and friends for free on Skype.",
+	"license": "Adware",
+	"proprietary": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/steam.plugin/metadata.json
+++ b/plugins/steam.plugin/metadata.json
@@ -2,6 +2,7 @@
 	"icon": "steam",
 	"label": "Steam",
 	"description": "The ultimate online game platform.",
+	"proprietary": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/sublimetext.plugin/metadata.json
+++ b/plugins/sublimetext.plugin/metadata.json
@@ -2,6 +2,7 @@
 	"icon": "sublime-text",
 	"label": "Sublime Text 3",
 	"description": "Sophisticated text editor for code, markup and prose (beta).",
+	"proprietary": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/sublimetext2.plugin/metadata.json
+++ b/plugins/sublimetext2.plugin/metadata.json
@@ -2,6 +2,7 @@
 	"icon": "sublime_text",
 	"label": "Sublime Text 2",
 	"description": "Sophisticated text editor for code, markup and prose.",
+	"proprietary": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/teamviewer.plugin/metadata.json
+++ b/plugins/teamviewer.plugin/metadata.json
@@ -2,6 +2,8 @@
 	"icon": "teamviewer",
 	"label": "TeamViewer",
 	"description": "Easy, fast and secure remote access to Windows, Mac and Linux systems.",
+	"license": "Free for non-commercial usage",
+	"proprietary": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/telegram.plugin/metadata.json
+++ b/plugins/telegram.plugin/metadata.json
@@ -2,6 +2,9 @@
 	"icon": "telegram",
 	"label": "Telegram",
 	"description": "A messaging app with a focus on speed and security.",
+	"license": "GPLv2 client, proprietary server",
+	"libre": true,
+	"proprietary": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/viber.plugin/metadata.json
+++ b/plugins/viber.plugin/metadata.json
@@ -2,6 +2,8 @@
 	"icon": "viber",
 	"label": "Viber",
 	"description": "Free calls, text and picture sharing with anyone, anywhere.",
+	"license": "Adware",
+	"proprietary": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/vivaldi.plugin/metadata.json
+++ b/plugins/vivaldi.plugin/metadata.json
@@ -2,6 +2,7 @@
 	"icon": "vivaldi",
 	"label": "Vivaldi",
 	"description": "An advanced browser made with the power user in mind.",
+	"proprietary": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/webstorm.plugin/metadata.json
+++ b/plugins/webstorm.plugin/metadata.json
@@ -2,6 +2,8 @@
 	"icon": "webstorm",
 	"label": "WebStorm",
 	"description": "The Smartest JavaScript IDE.",
+	"license": "Commercial",
+	"proprietary": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {

--- a/plugins/wpsoffice.plugin/metadata.json
+++ b/plugins/wpsoffice.plugin/metadata.json
@@ -2,6 +2,7 @@
 	"icon": "wps-office",
 	"label": "WPS Office",
 	"description": "Simple, powerful office suite with a comfortable interface.",
+	"proprietary": true,
 	"category": "Apps",
 	"scripts": {
 		"exec": {


### PR DESCRIPTION
As suggested in issue #211, here is an attempt to add new metadata to describe software licenses, and some code to display such information.

Note that this is a first sketch, I am not sure at all that the fields I've added are the right ones, and anything/everything can be reworked. Don't hesitate to reject all this :)

Regarding **metadata**, here are the fields I've added:

- `license`, a string to describe the license (e.g. GPLv3, Commercial)
- `libre`, a boolean to state that the plugin contains libre software
- `proprietary`, a boolean to state that that this is proprietary software
- `patented`, a boolean to state that it contains patented techniques

All the information was mostly taken from Wikipedia, RPMs metadata and Official web pages.

Regarding the **code**, it impacts the number of rows used by a plugin description, hence I've added an early check to know whether we need 2 or 3 rows (`has_license` boolean). Then to display the license, it works the following way:

- If only the `libre` boolean is true, it displays "Libre"
- If only the `proprietary` boolean is true, it displays "Proprietary"
- If only the `patented` boolean is true, it displays "Patented"
- In other cases, it displays "Mixed"

Then the license description is given in between parentheses.

Here is what it currently looks like:
![capture d ecran de 2015-06-30 16-13-23](https://cloud.githubusercontent.com/assets/1388961/8432887/02a4b8c0-1f43-11e5-981e-1584d53effba.png)
