### PR TITLE
Fixing Popcorn-Time URL

### DIFF
--- a/plugins/popcorntime.plugin/install.sh
+++ b/plugins/popcorntime.plugin/install.sh
@@ -11,7 +11,7 @@ fi
 mkdir -p "$CACHEDIR"
 cd "$CACHEDIR"
 
-URL=$(wget "https://popcorntime.io" -O - | grep -o "https://get.popcorntime.io/build/Popcorn-Time-[0-9.]*-Linux${ARCH}.tar.xz" | head -n 1)
+URL=$(wget "https://popcorntime.io" -O - | grep -o "https://get.popcorntime.io/build/Popcorn-Time-[0-9.\-]*Linux-${ARCH}.tar.xz" | head -n 1)
 FILE=${URL##*/}
 
 wget -c "$URL" -O "$FILE"


### PR DESCRIPTION
On this new version of Popcorn Time: 3.8, they changed the URL format:

https://get.popcorntime.io/build/Popcorn-Time-0.3.8-0-Linux-64.tar.xz