### PR TITLE
Fix installer code to work in all shells

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
                     <p>To install Fedy in Fedora, open a Terminal and run the following command,</p>
 
                     <div class="code">
-                        <code>su -c "curl <a href="https://satya164.github.io/fedy/fedy-installer">https://satya164.github.io/fedy/fedy-installer</a> -o fedy-installer && chmod +x fedy-installer && ./fedy-installer"</code>
+                        <code>'bash -c "su -c "curl <a href="https://satya164.github.io/fedy/fedy-installer">https://satya164.github.io/fedy/fedy-installer</a> -o fedy-installer && chmod +x fedy-installer && ./fedy-installer" " '</code>
                     </div>
 
                     <div class="social">


### PR DESCRIPTION
This should make the installer script run in a bash shell regardless of the shell it's called from.