### PR TITLE
Fix: Download link regex for Popcorn-Time 0.3.8 onwards.

### DIFF
--- a/plugins/popcorntime.plugin/install.sh
+++ b/plugins/popcorntime.plugin/install.sh
@@ -11,7 +11,7 @@ fi
 mkdir -p "$CACHEDIR"
 cd "$CACHEDIR"
 
-URL=$(wget "https://popcorntime.io" -O - | grep -o "https://get.popcorntime.io/build/Popcorn-Time-[0-9.]*-Linux${ARCH}.tar.xz" | head -n 1)
+URL=$(wget "https://popcorntime.io" -O - | grep -o "https://get.popcorntime.io/build/\S*${ARCH}.tar.xz" | head -n 1)
 FILE=${URL##*/}
 
 wget -c "$URL" -O "$FILE"


### PR DESCRIPTION
The `grep` command would not match the new URL format:
```
OLD: https://get.popcorntime.io/build/Popcorn-Time-0.3.7.2-Linux64.tar.xz
NEW: https://get.popcorntime.io/build/Popcorn-Time-0.3.8-0-Linux-64.tar.xz
```
It does not look for the linux string anymore, but the `.tar.xz` extension should be enough to discriminate against a Windows or Mac version.